### PR TITLE
attempt to add definition of epsg:2056

### DIFF
--- a/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/crs-definitions.xml
+++ b/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/crs-definitions.xml
@@ -4427,9 +4427,6 @@
         </crs:GeographicCRS>
         <crs:GeographicCRS>
                 <crs:Id>epsg:4150</crs:Id>
-                <crs:Id>http://www.opengis.net/gml/srs/epsg.xml#4150</crs:Id>
-                <crs:Id>urn:ogc:def:crs:epsg::4150</crs:Id>
-                <crs:Id>urn:opengis:def:crs:epsg::4150</crs:Id>
                 <crs:Name>CH1903+</crs:Name>
                 <crs:Version>2008-1-16T9:49</crs:Version>
                 <crs:Description>Handmade proj4 geographic crs definition (parsed from nad/epsg).</crs:Description>
@@ -4446,6 +4443,26 @@
                         <crs:AxisOrientation>north</crs:AxisOrientation>
                 </crs:Axis>
                 <crs:UsedDatum>epsg:6149</crs:UsedDatum>
+        </crs:GeographicCRS>
+        <crs:GeographicCRS>
+                <crs:Id>http://www.opengis.net/gml/srs/epsg.xml#4150</crs:Id>
+                <crs:Id>urn:ogc:def:crs:epsg::4150</crs:Id>
+                <crs:Id>urn:opengis:def:crs:epsg::4150</crs:Id>
+                <crs:Name>CH1903+</crs:Name>
+                <crs:Version>2015-11-25</crs:Version>
+                <crs:AreaOfUse>5.96,45.82,10.49,47.81</crs:AreaOfUse>
+                <crs:AreaOfUse>Liechtenstein; Switzerland.</crs:AreaOfUse>
+                <crs:Axis>
+                        <crs:Name>latitude</crs:Name>
+                        <crs:Units>degree</crs:Units>
+                        <crs:AxisOrientation>north</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:Axis>
+                        <crs:Name>longitude</crs:Name>
+                        <crs:Units>degree</crs:Units>
+                        <crs:AxisOrientation>east</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:UsedDatum>epsg:6150</crs:UsedDatum>
         </crs:GeographicCRS>
         <crs:GeographicCRS>
                 <crs:Id>epsg:4151</crs:Id>
@@ -9857,6 +9874,28 @@
                 </crs:Axis>
                 <crs:UsedGeographicCRS>urn:opengis:def:crs:epsg::4634</crs:UsedGeographicCRS>
                 <crs:UsedProjection>epsg:16036</crs:UsedProjection>
+        </crs:ProjectedCRS>
+        <crs:ProjectedCRS>
+                <crs:Id>epsg:2056</crs:Id>
+                <crs:Id>http://www.opengis.net/gml/srs/epsg.xml#2056</crs:Id>
+                <crs:Id>urn:ogc:def:crs:epsg::2056</crs:Id>
+                <crs:Id>urn:opengis:def:crs:epsg::2056</crs:Id>
+                <crs:Name>CH1903+ / LV95</crs:Name>
+                <crs:Version>2015-11-25</crs:Version>
+                <crs:AreaOfUse>5.96,45.82,10.49,47.81</crs:AreaOfUse>
+                <crs:AreaOfUse>Liechtenstein; Switzerland.</crs:AreaOfUse>
+                <crs:Axis>
+                        <crs:Name>x</crs:Name>
+                        <crs:Units>metre</crs:Units>
+                        <crs:AxisOrientation>east</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:Axis>
+                        <crs:Name>y</crs:Name>
+                        <crs:Units>metre</crs:Units>
+                        <crs:AxisOrientation>north</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:UsedGeographicCRS>urn:opengis:def:crs:epsg::4150</crs:UsedGeographicCRS>
+                <crs:UsedProjection>epsg:19950</crs:UsedProjection>
         </crs:ProjectedCRS>
         <crs:ProjectedCRS>
                 <crs:Id>epsg:2063</crs:Id>

--- a/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/datum-definitions.xml
+++ b/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/datum-definitions.xml
@@ -218,6 +218,13 @@
       <crs:UsedPrimeMeridian>urn:opengis:def:crs:epsg::8901</crs:UsedPrimeMeridian>
     </crs:GeodeticDatum>
     <crs:GeodeticDatum>
+      <crs:Id>epsg:6150</crs:Id>
+      <crs:Name>CH1903+</crs:Name>
+      <crs:Version>2001-11-06</crs:Version>
+      <crs:UsedEllipsoid>http://www.opengis.net/gml/srs/epsg.xml#7004</crs:UsedEllipsoid>
+      <crs:UsedPrimeMeridian>urn:opengis:def:crs:epsg::8901</crs:UsedPrimeMeridian>
+    </crs:GeodeticDatum>
+    <crs:GeodeticDatum>
       <crs:Id>epsg:6153</crs:Id>
       <crs:Name>Rassadiran</crs:Name>
       <crs:Version>2008-06-24</crs:Version>

--- a/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/projection-definitions.xml
+++ b/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/projection-definitions.xml
@@ -10532,6 +10532,15 @@
 		<crs:FalseNorthing>75000.0</crs:FalseNorthing>
 	</crs:TransverseMercator>
 	<crs:TransverseMercator>
+		<crs:Id>epsg:19950</crs:Id>
+		<crs:Name>Swiss Oblique Mercator 1995</crs:Name>
+		<crs:LatitudeOfNaturalOrigin>46.952405555556</crs:LatitudeOfNaturalOrigin>
+		<crs:LongitudeOfNaturalOrigin>7.439583333333</crs:LongitudeOfNaturalOrigin>
+		<crs:ScaleFactor>1.0</crs:ScaleFactor>
+		<crs:FalseEasting>2600000.0</crs:FalseEasting>
+		<crs:FalseNorthing>1200000.0</crs:FalseNorthing>
+	</crs:TransverseMercator>
+	<crs:TransverseMercator>
 		<crs:Id>epsg:19954</crs:Id>
 		<crs:Name>Suriname Old TM</crs:Name>
 		<crs:LatitudeOfNaturalOrigin>0.0</crs:LatitudeOfNaturalOrigin>


### PR DESCRIPTION
Attempt to manually add epsg:2056. I used information from the EPSG registry and tried to create the definition for deegree based on the example of epsg:21781 which seems to be the predecessor of epsg:2056.

- I added the definition of epsg:2056.
- I added the definition of epsg:19950
- I adapted the existing definition of epsg:4150 which was lon/lat in all cases but is lat/lon in the EPSG registry. I split the definition in two parts (depending on the authority style), similar to how it was already done for epsg:4258.
- I added the datum epsg:6150, which seemingly has no difference to the datum epsg:6149.

I hope I will never have to touch CRS definitions in deegree again...

BTW - the existing definition for epsg:4150 seemed to suffer from the same problem as identified in https://github.com/halestudio/hale/issues/597, that the definition used in proj4 and on spatialreference.org uses lon/lat while the EPSG registry uses lat/lon.

@doemming Do you know an easy way for testing this?