### PR TITLE
Adapted CRS improvements from master-3.3.18-we

### DIFF
--- a/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/crs-definitions.xml
+++ b/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/crs-definitions.xml
@@ -4648,10 +4648,6 @@
         </crs:GeographicCRS>
         <crs:GeographicCRS>
                 <crs:Id>epsg:4150</crs:Id>
-                <crs:Id>http://www.opengis.net/gml/srs/epsg.xml#4150</crs:Id>
-                <crs:Id>http://www.opengis.net/def/crs/EPSG/0/4150</crs:Id>
-                <crs:Id>urn:ogc:def:crs:epsg::4150</crs:Id>
-                <crs:Id>urn:opengis:def:crs:epsg::4150</crs:Id>
                 <crs:Name>CH1903+</crs:Name>
                 <crs:Version>2008-1-16T9:49</crs:Version>
                 <crs:Description>Handmade proj4 geographic crs definition (parsed from nad/epsg).</crs:Description>
@@ -4666,6 +4662,28 @@
                         <crs:Name>latitude</crs:Name>
                         <crs:Units>degree</crs:Units>
                         <crs:AxisOrientation>north</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:UsedDatum>epsg:6149</crs:UsedDatum>
+        </crs:GeographicCRS>
+        <crs:GeographicCRS>
+                <crs:Id>http://www.opengis.net/gml/srs/epsg.xml#4150</crs:Id>
+                <crs:Id>http://www.opengis.net/def/crs/EPSG/0/4150</crs:Id>
+                <crs:Id>urn:ogc:def:crs:epsg::4150</crs:Id>
+                <crs:Id>urn:opengis:def:crs:epsg::4150</crs:Id>
+                <crs:Name>CH1903+</crs:Name>
+                <crs:Version>2008-1-16T9:49</crs:Version>
+                <crs:Description>lat/long variant of EPSG:4150</crs:Description>
+                <crs:AreaOfUse>5.97,45.83,10.49,47.81</crs:AreaOfUse>
+                <crs:AreaOfUse>Liechtenstein; Switzerland.</crs:AreaOfUse>
+                <crs:Axis>
+                        <crs:Name>latitude</crs:Name>
+                        <crs:Units>degree</crs:Units>
+                        <crs:AxisOrientation>north</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:Axis>
+                        <crs:Name>longitude</crs:Name>
+                        <crs:Units>degree</crs:Units>
+                        <crs:AxisOrientation>east</crs:AxisOrientation>
                 </crs:Axis>
                 <crs:UsedDatum>epsg:6149</crs:UsedDatum>
         </crs:GeographicCRS>
@@ -10298,6 +10316,29 @@
                 </crs:Axis>
                 <crs:UsedGeographicCRS>urn:opengis:def:crs:epsg::4634</crs:UsedGeographicCRS>
                 <crs:UsedProjection>epsg:16036</crs:UsedProjection>
+        </crs:ProjectedCRS>
+        <crs:ProjectedCRS>
+                <crs:Id>epsg:2056</crs:Id>
+                <crs:Id>http://www.opengis.net/gml/srs/epsg.xml#2056</crs:Id>
+                <crs:Id>http://www.opengis.net/def/crs/EPSG/0/2056</crs:Id>
+                <crs:Id>urn:ogc:def:crs:epsg::2056</crs:Id>
+                <crs:Id>urn:opengis:def:crs:epsg::2056</crs:Id>
+                <crs:Name>CH1903+ / LV95</crs:Name>
+                <crs:Version>2015-11-25</crs:Version>
+                <crs:AreaOfUse>5.96,45.82,10.49,47.81</crs:AreaOfUse>
+                <crs:AreaOfUse>Liechtenstein; Switzerland.</crs:AreaOfUse>
+                <crs:Axis>
+                        <crs:Name>x</crs:Name>
+                        <crs:Units>metre</crs:Units>
+                        <crs:AxisOrientation>east</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:Axis>
+                        <crs:Name>y</crs:Name>
+                        <crs:Units>metre</crs:Units>
+                        <crs:AxisOrientation>north</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:UsedGeographicCRS>urn:opengis:def:crs:epsg::4150</crs:UsedGeographicCRS>
+                <crs:UsedProjection>epsg:19950</crs:UsedProjection>
         </crs:ProjectedCRS>
         <crs:ProjectedCRS>
                 <crs:Id>epsg:2063</crs:Id>

--- a/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/projection-definitions.xml
+++ b/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/projection-definitions.xml
@@ -10532,6 +10532,15 @@
 		<crs:FalseNorthing>75000.0</crs:FalseNorthing>
 	</crs:TransverseMercator>
 	<crs:TransverseMercator>
+		<crs:Id>epsg:19950</crs:Id>
+		<crs:Name>Swiss Oblique Mercator 1995</crs:Name>
+		<crs:LatitudeOfNaturalOrigin>46.952405555556</crs:LatitudeOfNaturalOrigin>
+		<crs:LongitudeOfNaturalOrigin>7.439583333333</crs:LongitudeOfNaturalOrigin>
+		<crs:ScaleFactor>1.0</crs:ScaleFactor>
+		<crs:FalseEasting>2600000.0</crs:FalseEasting>
+		<crs:FalseNorthing>1200000.0</crs:FalseNorthing>
+	</crs:TransverseMercator>
+	<crs:TransverseMercator>
 		<crs:Id>epsg:19954</crs:Id>
 		<crs:Name>Suriname Old TM</crs:Name>
 		<crs:LatitudeOfNaturalOrigin>0.0</crs:LatitudeOfNaturalOrigin>


### PR DESCRIPTION
* Splitted definition of EPSG:4150 (use y/x order for new Identifiers)
* Added definition of EPSG:2056
* Separated definition of EPSG:3395 from EPSG:3857
* Added definition of EPSG:19950