### PR TITLE
Disable schema validation of deegree configuration files

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/jaxb/JAXBUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/jaxb/JAXBUtils.java
@@ -118,9 +118,10 @@ public class JAXBUtils {
             LOG.error( "Unable to instantiate JAXBContext for package '{}'", jaxbPackage );
             throw e;
         }
-
+        
+        boolean performValidation=false; // TODO read value from configuration or support validation with local schema locations
         Unmarshaller u = jc.createUnmarshaller();
-        if ( schemaLocation != null ) {
+        if ( schemaLocation != null && performValidation ) {
             Schema configSchema = getSchemaForUrl( schemaLocation );
             if ( configSchema != null ) {
                 u.setSchema( configSchema );


### PR DESCRIPTION
Ported from wetransform 3.3-branch. Ideally, we would put a config option into the deegree workspace somewhere, but currently there is no really suitable global config file for this.

Please pull and re-check initialization time on the test system.