### PR TITLE
Add cache for building XSModel instances from schema URLs

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/XMLSchemaInfoSet.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/XMLSchemaInfoSet.java
@@ -134,7 +134,7 @@ public class XMLSchemaInfoSet {
      */
     public XMLSchemaInfoSet( String... schemaUrls ) throws ClassCastException, ClassNotFoundException,
                             InstantiationException, IllegalAccessException {
-        xsModel = loadModel( schemaUrls );
+        xsModel = XSModelCache.getInstance().get( schemaUrls );
         init();
     }
 

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/XSModelCache.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/XSModelCache.java
@@ -1,0 +1,79 @@
+package org.deegree.commons.xml.schema;
+
+import static java.util.Arrays.copyOf;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.xerces.xs.XSModel;
+import org.slf4j.Logger;
+
+/**
+ * Minimalistic approach for caching XSModels created from schema URLs.
+ */
+public class XSModelCache {
+
+    private static final int MAX_ENTRIES = 100;
+
+    private static final Logger LOG = getLogger( XSModelCache.class );
+
+    private static XSModelCache INSTANCE;
+
+    private Map<String, XSModel> idsToSchemas = new LinkedHashMap<String, XSModel>() {
+
+        private static final long serialVersionUID = -2954560460595272023L;
+
+        @Override
+        protected boolean removeEldestEntry( Map.Entry<String, XSModel> eldest ) {
+            return size() > MAX_ENTRIES;
+        }
+    };
+
+    public static synchronized XSModelCache getInstance() {
+        if ( INSTANCE == null ) {
+            INSTANCE = new XSModelCache();
+        }
+        return INSTANCE;
+    }
+
+    public void clear() {
+        synchronized ( this ) {
+            LOG.info( "Clearing cache." );
+            idsToSchemas.clear();
+        }
+    }
+
+    public XSModel get( String... schemaUrls )
+                            throws ClassCastException,
+                            ClassNotFoundException,
+                            InstantiationException,
+                            IllegalAccessException {
+        synchronized ( this ) {
+            String id = getId( copyOf( schemaUrls, schemaUrls.length ) );
+            LOG.info( "Lookup: " + id );
+            XSModel schema = idsToSchemas.get( id );
+            if ( schema == null ) {
+                LOG.info( "Creating." );
+                schema = XMLSchemaInfoSet.loadModel( schemaUrls );
+                idsToSchemas.put( id, schema );
+                LOG.info( "Added to cache. Entries: " + idsToSchemas.size() );
+            } else {
+                LOG.info( "From cache." );
+            }
+            return schema;
+        }
+    }
+
+    private String getId( String... schemaUrls ) {
+        Arrays.sort( schemaUrls );
+        StringBuilder sb = new StringBuilder();
+        for ( String schemaUrl : schemaUrls ) {
+            sb.append( schemaUrl );
+            sb.append( ';' );
+        }
+        return sb.toString();
+    }
+
+}

--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
@@ -106,6 +106,7 @@ import org.deegree.commons.utils.io.LoggingInputStream;
 import org.deegree.commons.utils.kvp.KVPUtils;
 import org.deegree.commons.xml.XMLAdapter;
 import org.deegree.commons.xml.XMLProcessingException;
+import org.deegree.commons.xml.schema.XSModelCache;
 import org.deegree.commons.xml.stax.XMLInputFactoryUtils;
 import org.deegree.commons.xml.stax.XMLStreamUtils;
 import org.deegree.feature.stream.ThreadedFeatureInputStream;
@@ -1182,6 +1183,7 @@ public class OGCFrontController extends HttpServlet {
         if ( requestWatchdog != null ) {
             requestWatchdog.destroy();
         }
+        XSModelCache.getInstance().clear();
         LOG.info( "" );
     }
 


### PR DESCRIPTION
Adds a (very minimalistic) cache to deegree's schema subsystem. When creating Xerces XSModel instances from schema URLs (e.g. for SQLFeatureStores), this cache will be used. Cache is cleared when workspace is destroyed.