### PR TITLE
XmlCatalogResolver: Fix redirection of the ogcschemas: protocol

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/XmlCatalogResolver.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/XmlCatalogResolver.java
@@ -11,7 +11,10 @@ import org.apache.xerces.xni.parser.XMLInputSource;
 /**
  * Wraps an {@link XMLCatalogResolver} to add support for the custom "ocgschemas:" protocol.
  * <p>
- * Redirects "ogcschemas:" to "/META-INF/SCHEMAS_OPENGIS_NET" on the classpath, enabling access to the ogcschemas JAR.
+ * In order to supersede the functionality of the old <code>RedirectingEntityResolver</code>, this resolver adds another
+ * layer of redirection. In addition to the resolving of the underlying catalog resolver, it replaces the String
+ * "ogcschemas:" (in resolved URLs) with the URL of "/META-INF/SCHEMAS_OPENGIS_NET" on the classpath, enabling access to
+ * the files in the ogcschemas JAR.
  * </p>
  */
 public class XmlCatalogResolver implements XMLEntityResolver {
@@ -24,7 +27,12 @@ public class XmlCatalogResolver implements XMLEntityResolver {
 
     XmlCatalogResolver( XMLCatalogResolver resolver ) {
         this.resolver = resolver;
-        this.ogcSchemasBaseUrl = XMLCatalogResolver.class.getResource( "/META-INF/SCHEMAS_OPENGIS_NET" ).toString();
+        String ogcSchemasBaseUrl = XMLCatalogResolver.class.getResource( "/META-INF/SCHEMAS_OPENGIS_NET" ).toString();
+        if ( ogcSchemasBaseUrl.endsWith( "/" ) ) {
+            // depending on the classloader, a trailing "/" may be present or not
+            ogcSchemasBaseUrl = ogcSchemasBaseUrl.substring( 0, ogcSchemasBaseUrl.length() - 1 );
+        }
+        this.ogcSchemasBaseUrl = ogcSchemasBaseUrl;
     }
 
     @Override

--- a/deegree-core/deegree-core-commons/src/main/resources/appschemas/catalog.xml
+++ b/deegree-core/deegree-core-commons/src/main/resources/appschemas/catalog.xml
@@ -4,6 +4,7 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
 	prefer="public">
 	<rewriteSystem systemIdStartString="http://portele.de/" rewritePrefix="./portele.de/"/>
+	<!--  ogcschemas: pseudo protocol that is replaced with a URL that points into the deegree-ogcschemas JAR -->
 	<rewriteSystem systemIdStartString="http://schemas.opengis.net/" rewritePrefix="ogcschemas:/"/>
 	<rewriteSystem systemIdStartString="http://www.w3.org/" rewritePrefix="./www.w3.org/"/>
 </catalog>


### PR DESCRIPTION
Before the fix, the generated URLs would sometimes be incorrect, depending on your classloader setup. While URLs generated running JUnit tests would be ok, URLs generated inside a Tomcat webapp would contain duplicate slashes ("//").