### PR TITLE
build(Docker): use Tomcat 8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cd /build/ && \
   unzip -o /build/deegree-webservices.war -d /target
 
 # add to image...
-FROM tomcat:8.0-jre8
+FROM tomcat:8.5-jre8
 ENV LANG en_US.UTF-8
 
 # add build info - see hooks/build and https://github.com/opencontainers/image-spec/blob/master/annotations.md


### PR DESCRIPTION
Tomcat 8.0 line [has reached end of life](https://tomcat.apache.org/tomcat-80-eol.html). With this commit the Dockerfile is consistent with the custom branches in my repo (e.g. lvermgeo-rlp) and also the [official deegree Dockerfile](https://github.com/deegree/deegree3-docker).