### PR TITLE
GMLWriter: Ensure binding of xsi-prefix when writing empty (but nilled) elements

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
@@ -466,7 +466,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
 
     private void writeNilAttributes( Map<QName, PrimitiveValue> attributes )
                             throws XMLStreamException {
-        writeAttribute( writer, XSI_NIL, "true" );
+        writeAttributeWithNS( XSI_NIL.getNamespaceURI(), XSI_NIL.getLocalPart(), "true" );
         PrimitiveValue value = attributes.get( NIL_REASON );
         if ( value != null )
             writeAttribute( writer, NIL_REASON, value.getAsText() );


### PR DESCRIPTION
Usually the xsi prefix will be bound in the root element, but for some cases (GetFeatureInfo) this may not be the case. This fix ensures that the xsi prefix is bound on the respective element, if it isn't already bound.