### PR TITLE
Fix redirected schema locations in DescribeFeatureTypeHandler

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/WellKnownSchemaManager.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/WellKnownSchemaManager.java
@@ -21,6 +21,7 @@ import org.apache.xerces.parsers.XMLGrammarPreparser;
 import org.apache.xerces.util.SymbolTable;
 import org.apache.xerces.util.XMLCatalogResolver;
 import org.apache.xerces.util.XMLGrammarPoolImpl;
+import org.apache.xerces.xni.XMLResourceIdentifier;
 import org.apache.xerces.xni.XNIException;
 import org.apache.xerces.xni.grammars.XMLGrammarPool;
 import org.apache.xerces.xni.parser.XMLInputSource;
@@ -125,6 +126,21 @@ public class WellKnownSchemaManager implements Initializable {
             return systemId;
         }
         return resolved;
+    }
+
+    /**
+     * Returns the original system id for the given redirected system id.
+     * <p>
+     * This only works for system ids that have been redirected, i.e. that have either been returned by
+     * {@link #redirect(String)} or by the underlying {@link XmlCatalogResolver}.
+     * </p>
+     *
+     * @param redirectedSystemId
+     *                               redirected system id
+     * @return original (unredirected) system id
+     */
+    public static String undirect( String redirectedSystemId ) {
+        return getInstance().getCatalogResolver().unresolveSystem( redirectedSystemId );
     }
 
     @Override


### PR DESCRIPTION
Fixes a problem caused by the introduction of the WellKnownSchemaManager.

Redirected schema URLs were exported with the redirected location in the DescribeFeatureTypeHandler,  e.g.

```
jar:file:/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/deegree-core-commons-3.4.3.jar!/appschemas/portele.de/ShapeChangeAppinfo.xsd
```

instead of

```
http://portele.de/ShapeChangeAppinfo.xsd
```