### PR TITLE
Workaround for memory leaks in RasterCache

### DIFF
--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/MultiResolutionRaster.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/MultiResolutionRaster.java
@@ -69,7 +69,7 @@ public class MultiResolutionRaster extends AbstractCoverage {
 
     private static final Logger LOG = LoggerFactory.getLogger( MultiResolutionRaster.class );
 
-    private List<AbstractRaster> resolutions = new LinkedList<AbstractRaster>();
+    private final List<AbstractRaster> resolutions = new LinkedList<AbstractRaster>();
 
     private ResolutionInfo resolutionInfo;
 
@@ -203,6 +203,13 @@ public class MultiResolutionRaster extends AbstractCoverage {
     @Override
     public void init() {
         // nothing to do
+    }
+
+    @Override
+    public void destroy() {
+        for ( AbstractRaster res : resolutions ) {
+            res.destroy();
+        }
     }
 
 }

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/SimpleRaster.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/SimpleRaster.java
@@ -43,7 +43,6 @@ import org.deegree.coverage.raster.geom.RasterGeoReference;
 import org.deegree.coverage.raster.geom.RasterGeoReference.OriginLocation;
 import org.deegree.coverage.raster.geom.RasterRect;
 import org.deegree.geometry.Envelope;
-import org.deegree.workspace.Resource;
 import org.deegree.workspace.ResourceMetadata;
 
 /**
@@ -310,6 +309,11 @@ public class SimpleRaster extends AbstractRaster {
     @Override
     public void init() {
         // nothing to do
+    }
+
+    @Override
+    public void destroy () {
+        dispose();
     }
 
 }

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
@@ -74,6 +74,10 @@ import org.slf4j.Logger;
  */
 public class RasterCache {
 
+    // Disables the caching mechanism to workaround inherent memory leak issues
+    // TODO Remove class altogether or fix it properly
+    private static final boolean DISABLE_CACHE = true;
+
     private static final Logger LOG = getLogger( RasterCache.class );
 
     /**
@@ -485,7 +489,9 @@ public class RasterCache {
                 }
                 result = new CacheRasterReader( reader, cacheFile, this );
             }
-            addReader( result );
+            if ( !DISABLE_CACHE ) {
+                addReader( result );
+            }
         } else {
             LOG.debug( "Not adding reader to cache, because it is was null." );
         }


### PR DESCRIPTION
Before this fix, the RasterCache accumulated RasterCacheReader instances. As the cache design is rather involved, the workaround does not try to fix the design issues, but disables the caching of RasterCacheReader instances altogether. This appears acceptable for raster formats that provide fast and indexed access (e.g. GeoTIFF with overlays).