### PR TITLE
Disable broken raster cache test case

### DIFF
--- a/deegree-core/deegree-core-coverage/src/test/java/org/deegree/coverage/raster/cache/TestRasterCache.java
+++ b/deegree-core/deegree-core-coverage/src/test/java/org/deegree/coverage/raster/cache/TestRasterCache.java
@@ -59,6 +59,7 @@ import org.deegree.coverage.raster.utils.RasterFactory;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.geometry.Envelope;
 import org.deegree.geometry.GeometryFactory;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -183,6 +184,7 @@ public class TestRasterCache {
      * @throws URISyntaxException
      */
     @Test
+    @Ignore ("raster cache disabled")
     public void testTileCache()
                             throws IOException, URISyntaxException {
         setRasterCache();


### PR DESCRIPTION
This was caused by disabling the raster cache in #46.