### PR TITLE
Speed up execution of deegree unit tests 

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/test/java/org/deegree/protocol/csw/client/getrecords/TestGetRecordsXMLEncoderTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/test/java/org/deegree/protocol/csw/client/getrecords/TestGetRecordsXMLEncoderTest.java
@@ -40,13 +40,13 @@ import static org.deegree.commons.xml.CommonNamespaces.APISO_PREFIX;
 import static org.deegree.filter.MatchAction.ANY;
 import static org.deegree.protocol.csw.CSWConstants.ResultType.results;
 import static org.deegree.protocol.csw.CSWConstants.ReturnableElement.full;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 
@@ -55,16 +55,13 @@ import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
-import javax.xml.validation.Validator;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.deegree.commons.tom.ows.Version;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.commons.xml.CommonNamespaces;
+import org.deegree.commons.xml.schema.SchemaValidationEvent;
+import org.deegree.commons.xml.schema.SchemaValidator;
 import org.deegree.cs.exceptions.TransformationException;
 import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.filter.Expression;
@@ -76,7 +73,6 @@ import org.deegree.filter.expression.Literal;
 import org.deegree.filter.expression.ValueReference;
 import org.deegree.protocol.csw.CSWConstants.ResultType;
 import org.deegree.protocol.csw.CSWConstants.ReturnableElement;
-import org.junit.Assume;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
@@ -206,19 +202,8 @@ public class TestGetRecordsXMLEncoderTest {
     private void validateGetRecordsXml( ByteArrayOutputStream os )
                             throws SAXException, IOException {
         InputStream getRecordsRequest = new ByteArrayInputStream( os.toByteArray() );
-        SchemaFactory factory = SchemaFactory.newInstance( "http://www.w3.org/2001/XMLSchema" );
-        Validator validator = null;
-        Source source = null;
-        try {
-            URL schemaLocation = new URL( "http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd" );
-            Schema schema = factory.newSchema( schemaLocation );
-            validator = schema.newValidator();
-            source = new StreamSource( getRecordsRequest );
-        } catch ( Exception e ) {
-            Assume.assumeNoException( e );
-            return;
-        }
-        validator.validate( source );
+        List<SchemaValidationEvent> events = SchemaValidator.validate( getRecordsRequest, "http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd" );
+        assertEquals( 0, events.size() );
     }
 
     private String asString( ByteArrayOutputStream getRecordsAsXml )


### PR DESCRIPTION
Reduces execution time of unit tests by 2,5 minutes by replacing custom XML validation code in one test class with the common validation utilities of deegree.